### PR TITLE
Fix typo in Nginx configuration by removing 'nginx' prefix from liste…

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,7 +27,7 @@ server {
 
 # Main application (costnav.com)
 server {
-    nginx listen 443 ssl;
+    listen 443 ssl;
     http2 on;
     server_name costnav.com www.costnav.com;
     


### PR DESCRIPTION
…n directive